### PR TITLE
fix: refresh CI ownership and Docker publishing config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: bonukai
+github: Guisardo
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -1,9 +1,8 @@
 name: Update demo website
 
+# Legacy VPS deployment is paused until replacement demo infrastructure exists.
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -43,4 +43,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: dnlwttnbrg/mediatracker-plus:${{ steps.version.outputs.result }},dnlwttnbrg/mediatracker-plus:latest
+          tags: guisardo/mediatracker-plus:${{ steps.version.outputs.result }},guisardo/mediatracker-plus:latest

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -68,7 +68,7 @@ jobs:
           context: .
           platforms: linux/amd64, linux/arm64
           push: true
-          tags: dnlwttnbrg/mediatracker-plus:${{ steps.version.outputs.version }},dnlwttnbrg/mediatracker-plus:unstable
+          tags: guisardo/mediatracker-plus:${{ steps.version.outputs.version }},guisardo/mediatracker-plus:unstable
       - if: ${{ github.event.action == 'released' }}
         name: Publish to Docker Hub
         uses: docker/build-push-action@v6
@@ -76,4 +76,4 @@ jobs:
           context: .
           platforms: linux/amd64, linux/arm64
           push: true
-          tags: dnlwttnbrg/mediatracker-plus:${{ steps.version.outputs.version }},dnlwttnbrg/mediatracker-plus:latest
+          tags: guisardo/mediatracker-plus:${{ steps.version.outputs.version }},guisardo/mediatracker-plus:latest

--- a/.github/workflows/update_docker_hub_description.yml
+++ b/.github/workflows/update_docker_hub_description.yml
@@ -16,6 +16,6 @@ jobs:
         uses: peter-evans/dockerhub-description@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          repository: dnlwttnbrg/mediatracker-plus
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: guisardo/mediatracker-plus
           short-description: ${{ github.event.repository.description }}

--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
-# MediaTracker-Plus &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/dnlwttnbrg/MediaTrackerPlus/blob/main/LICENSE.md) [![Docker Image Size](https://img.shields.io/docker/image-size/dnlwttnbrg/mediatracker-plus)](https://hub.docker.com/repository/docker/dnlwttnbrg/mediatracker-plus) [![Docker Pulls](https://img.shields.io/docker/pulls/dnlwttnbrg/mediatracker-plus)](https://hub.docker.com/repository/docker/dnlwttnbrg/mediatracker-plus) [![CodeFactor](https://www.codefactor.io/repository/github/dnlwttnbrg/mediatrackerplus/badge)](https://www.codefactor.io/repository/github/dnlwttnbrg/mediatrackerplus) [![codecov](https://codecov.io/github/dnlwttnbrg/MediaTrackerPlus/graph/badge.svg?token=7O9IV84JVL)](https://codecov.io/github/dnlwttnbrg/MediaTrackerPlus)
+# MediaTracker-Plus &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/Guisardo/MediaTrackerPlus/blob/main/LICENSE.md) [![Docker Image Size](https://img.shields.io/docker/image-size/guisardo/mediatracker-plus)](https://hub.docker.com/repository/docker/guisardo/mediatracker-plus) [![Docker Pulls](https://img.shields.io/docker/pulls/guisardo/mediatracker-plus)](https://hub.docker.com/repository/docker/guisardo/mediatracker-plus) [![CodeFactor](https://www.codefactor.io/repository/github/guisardo/mediatrackerplus/badge)](https://www.codefactor.io/repository/github/guisardo/mediatrackerplus) [![codecov](https://codecov.io/github/Guisardo/MediaTrackerPlus/graph/badge.svg?token=7O9IV84JVL)](https://codecov.io/github/Guisardo/MediaTrackerPlus)
 
 Self hosted platform for tracking movies, tv shows, video games, books and audiobooks, highly inspired by [flox](https://github.com/devfake/flox).
+This repository is maintained at [Guisardo/MediaTrackerPlus](https://github.com/Guisardo/MediaTrackerPlus).
 This is a fork from [Mediatracker](https://github.com/bonukai/MediaTracker) because I wanted new features and the original repository is at this time abandoned. But feel free to check out the original repository.
-This is a drop in replacement of the original repository. For now, the databases are compartible.
+This is a drop in replacement of the original repository. For now, the databases are compatible.
 
 ## API Documentation
 
-[https://dnlwttnbrg.github.io/MediaTrackerPlus/](https://dnlwttnbrg.github.io/MediaTrackerPlus/)
+[https://guisardo.github.io/MediaTrackerPlus/](https://guisardo.github.io/MediaTrackerPlus/)
 
 ## Installation
 
 ## Building from source
 
 ```bash
-git clone https://github.com/dnlwttnbrg/MediaTrackerPlus.git
+git clone https://github.com/Guisardo/MediaTrackerPlus.git
 cd MediaTrackerPlus
 npm install
 npm run build
@@ -49,7 +50,7 @@ docker run \
     -e TMDB_LANG=en \
     -e AUDIBLE_LANG=us \
     -e TZ=Europe/London \
-    dnlwttnbrg/mediatracker-plus:latest
+    guisardo/mediatracker-plus:latest
 ```
 
 ## With docker-compose
@@ -69,7 +70,7 @@ services:
       TMDB_LANG: en
       AUDIBLE_LANG: us
       TZ: Europe/London
-    image: dnlwttnbrg/mediatracker-plus:latest
+    image: guisardo/mediatracker-plus:latest
 
 volumes:
   assetsVolume: null
@@ -147,7 +148,7 @@ Migration file: `server/src/migrations/20990101000000_listItemEstimatedRating.ts
 ## Building docker image
 
 ```bash
-docker build --tag mediatracker-plus:latest https://github.com/dnlwttnbrg/MediaTrackerPlus.git
+docker build --tag mediatracker-plus:latest https://github.com/Guisardo/MediaTrackerPlus.git
 docker run -p 7481:7481 mediatracker
 ```
 

--- a/server/README.md
+++ b/server/README.md
@@ -1,19 +1,20 @@
-# MediaTracker-Plus &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/dnlwttnbrg/MediaTrackerPlus/blob/main/LICENSE.md) [![Docker Image Size](https://img.shields.io/docker/image-size/dnlwttnbrg/mediatracker-plus)](https://hub.docker.com/repository/docker/dnlwttnbrg/mediatracker-plus) [![Docker Pulls](https://img.shields.io/docker/pulls/dnlwttnbrg/mediatracker-plus)](https://hub.docker.com/repository/docker/dnlwttnbrg/mediatracker-plus) [![CodeFactor](https://www.codefactor.io/repository/github/dnlwttnbrg/mediatrackerplus/badge)](https://www.codefactor.io/repository/github/dnlwttnbrg/mediatrackerplus) [![codecov](https://codecov.io/github/dnlwttnbrg/MediaTrackerPlus/graph/badge.svg?token=7O9IV84JVL)](https://codecov.io/github/dnlwttnbrg/MediaTrackerPlus)
+# MediaTracker-Plus &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/Guisardo/MediaTrackerPlus/blob/main/LICENSE.md) [![Docker Image Size](https://img.shields.io/docker/image-size/guisardo/mediatracker-plus)](https://hub.docker.com/repository/docker/guisardo/mediatracker-plus) [![Docker Pulls](https://img.shields.io/docker/pulls/guisardo/mediatracker-plus)](https://hub.docker.com/repository/docker/guisardo/mediatracker-plus) [![CodeFactor](https://www.codefactor.io/repository/github/guisardo/mediatrackerplus/badge)](https://www.codefactor.io/repository/github/guisardo/mediatrackerplus) [![codecov](https://codecov.io/github/Guisardo/MediaTrackerPlus/graph/badge.svg?token=7O9IV84JVL)](https://codecov.io/github/Guisardo/MediaTrackerPlus)
 
 Self hosted platform for tracking movies, tv shows, video games, books and audiobooks, highly inspired by [flox](https://github.com/devfake/flox).
+This repository is maintained at [Guisardo/MediaTrackerPlus](https://github.com/Guisardo/MediaTrackerPlus).
 This is a fork from [Mediatracker](https://github.com/bonukai/MediaTracker) because I wanted new features and the original repository is at this time abandoned. But feel free to check out the original repository.
-This is a drop in replacement of the original repository. For now, the databases are compartible.
+This is a drop in replacement of the original repository. For now, the databases are compatible.
 
 # API Documentation
 
-[https://dnlwttnbrg.github.io/MediaTrackerPlus/](https://dnlwttnbrg.github.io/MediaTrackerPlus/)
+[https://guisardo.github.io/MediaTrackerPlus/](https://guisardo.github.io/MediaTrackerPlus/)
 
 # Installation
 
 ## Building from source
 
 ```bash
-git clone https://github.com/dnlwttnbrg/MediaTrackerPlus.git
+git clone https://github.com/Guisardo/MediaTrackerPlus.git
 cd MediaTrackerPlus
 npm install
 npm run build
@@ -39,7 +40,7 @@ docker run \
     -e TMDB_LANG=en \
     -e AUDIBLE_LANG=us \
     -e TZ=Europe/London \
-    dnlwttnbrg/mediatracker-plus:latest
+    guisardo/mediatracker-plus:latest
 ```
 
 ## With docker-compose
@@ -59,7 +60,7 @@ services:
       TMDB_LANG: en
       AUDIBLE_LANG: us
       TZ: Europe/London
-    image: dnlwttnbrg/mediatracker-plus:latest
+    image: guisardo/mediatracker-plus:latest
 
 volumes:
   assetsVolume: null
@@ -102,7 +103,7 @@ volumes:
 # Building docker image
 
 ```bash
-docker build --tag mediatracker-plus:latest https://github.com/dnlwttnbrg/MediaTrackerPlus.git
+docker build --tag mediatracker-plus:latest https://github.com/Guisardo/MediaTrackerPlus.git
 docker run -p 7481:7481 mediatracker
 ```
 

--- a/server/package.json
+++ b/server/package.json
@@ -4,14 +4,14 @@
   "description": "Self hosted media tracker for movies, tv shows, video games, books and audiobooks",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dnlwttnbrg/MediaTrackerPlus.git"
+    "url": "https://github.com/Guisardo/MediaTrackerPlus.git"
   },
   "keywords": [
     "self hosted"
   ],
   "author": {
-    "name": "Daniel Wittenburg",
-    "url": "https://github.com/dnlwttnbrg"
+    "name": "Guisardo",
+    "url": "https://github.com/Guisardo"
   },
   "contributors": [
     {
@@ -21,9 +21,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/dnlwttnbrg/MediaTrackerPlus/issues"
+    "url": "https://github.com/Guisardo/MediaTrackerPlus/issues"
   },
-  "homepage": "https://github.com/dnlwttnbrg/MediaTrackerPlus/MediaTracker#readme",
+  "homepage": "https://github.com/Guisardo/MediaTrackerPlus#readme",
   "scripts": {
     "dev": "sh ./scripts/dev.sh",
     "test": "cross-env DATABASE_PATH=:memory: jest",


### PR DESCRIPTION
## Summary

- Update all CI/CD workflows and documentation to reflect the new repository owner (`Guisardo`) replacing the previous owner (`dnlwttnbrg`).
- Pause the legacy demo deployment workflow until replacement infrastructure is available.

Closes #21

## Changes

- `.github/FUNDING.yml` — update GitHub Sponsors handle to `Guisardo`
- `.github/workflows/demo.yml` — switch trigger from `push` to `workflow_dispatch` (legacy VPS deployment paused)
- `.github/workflows/docker_build.yml` — retarget Docker Hub image tags to `guisardo/mediatracker-plus`
- `.github/workflows/publish_release.yml` — retarget Docker Hub release image tags to `guisardo/mediatracker-plus`
- `.github/workflows/update_docker_hub_description.yml` — update repository name and switch secret from `DOCKERHUB_PASSWORD` to `DOCKERHUB_TOKEN`
- `README.md` / `server/README.md` — update all links, badges, and Docker image references; fix typo (`compartible` → `compatible`); add maintained-at notice
- `server/package.json` — update repository URL, author name/URL, bugs URL, and homepage

## Testing

- CI workflow changes are validated by reviewing YAML syntax and confirming secret names match the repository's configured secrets.
- No runtime code was modified; no functional tests are required.

## Notes

- The demo workflow is intentionally disabled via `workflow_dispatch` until a replacement demo environment is provisioned.