### PR TITLE
fix(ci): shrink Docker Hub description payload

### DIFF
--- a/.github/workflows/update_docker_hub_description.yml
+++ b/.github/workflows/update_docker_hub_description.yml
@@ -6,16 +6,19 @@ on:
       - 'main'
     paths:
       - 'README.md'
+      - 'docs/dockerhub/README.md'
+      - '.github/workflows/update_docker_hub_description.yml'
 
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Update Docker Hub description
-        uses: peter-evans/dockerhub-description@v2
+        uses: peter-evans/dockerhub-description@v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: guisardo/mediatracker-plus
           short-description: ${{ github.event.repository.description }}
+          readme-filepath: ./docs/dockerhub/README.md

--- a/docs/dockerhub/README.md
+++ b/docs/dockerhub/README.md
@@ -1,0 +1,84 @@
+# MediaTrackerPlus
+
+Self-hosted media tracker for movies, TV shows, video games, books, and audiobooks.
+
+MediaTrackerPlus helps you manage a personal library, track progress, maintain a watchlist, and keep metadata synchronized across several media types from a single application.
+
+## Highlights
+
+- Multi-user support
+- Watchlist and calendar views
+- Notifications
+- REST API
+- Import from Trakt and Goodreads
+- Docker image for self-hosted deployment
+
+## Quick start
+
+```bash
+docker volume create assets
+
+docker run \
+  -d \
+  --name mediatracker-plus \
+  -p 7481:7481 \
+  -v /path/to/data:/storage \
+  -v assets:/assets \
+  -e SERVER_LANG=en \
+  -e TMDB_LANG=en \
+  -e AUDIBLE_LANG=us \
+  -e TZ=Europe/London \
+  guisardo/mediatracker-plus:latest
+```
+
+Open `http://localhost:7481` after the container starts.
+
+## Docker Compose
+
+```yaml
+services:
+  mediatracker:
+    image: guisardo/mediatracker-plus:latest
+    container_name: mediatracker-plus
+    ports:
+      - "7481:7481"
+    volumes:
+      - /path/to/data:/storage
+      - assetsVolume:/assets
+    environment:
+      SERVER_LANG: en
+      TMDB_LANG: en
+      AUDIBLE_LANG: us
+      TZ: Europe/London
+
+volumes:
+  assetsVolume:
+```
+
+## Common environment variables
+
+- `SERVER_LANG`: UI/server language. Supported values include `da`, `de`, `en`, `es`, `fr`, `ko`, and `pt`.
+- `TMDB_LANG`: TMDB metadata language.
+- `AUDIBLE_LANG`: Audible marketplace region such as `us`, `gb`, or `de`.
+- `DATABASE_CLIENT`: `better-sqlite3` or `pg`.
+- `DATABASE_PATH`: SQLite database path.
+- `DATABASE_URL`: Postgres connection string.
+- `ASSETS_PATH`: poster and backdrop storage path.
+- `LOGS_PATH`: application log path.
+- `HOSTNAME`: bind address.
+- `PORT`: listen port.
+- `TZ`: container time zone.
+
+## Integrations
+
+- TMDB for movies and TV metadata
+- IGDB for video game metadata
+- Open Library for books
+- Audible for audiobooks
+- Jellyfin, Plex, and Kodi integrations
+
+## Repository
+
+- Source: https://github.com/Guisardo/MediaTrackerPlus
+- Documentation: https://github.com/Guisardo/MediaTrackerPlus#readme
+- API docs: https://guisardo.github.io/MediaTrackerPlus/


### PR DESCRIPTION
## Summary

- add a compact Docker Hub specific README so the description upload stays below Docker Hub's 25 KB limit
- update the Docker Hub description workflow to publish that file instead of the repository root README
- bump the workflow actions used there to current versions while touching the job

## Changes

- add `docs/dockerhub/README.md` with a short container-focused description
- update `.github/workflows/update_docker_hub_description.yml` to watch the new file
- switch the workflow to `actions/checkout@v4`
- switch `peter-evans/dockerhub-description` to `@v5` and set `readme-filepath`

## Testing

- reproduced the failure from the GitHub Actions log: `File size exceeds the maximum allowed 25000 bytes`
- verified local file sizes: `README.md` is 28166 bytes and `docs/dockerhub/README.md` is 2116 bytes
- did not run the workflow locally