### PR TITLE
fix(ci): run required checks for merge groups

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -6,6 +6,7 @@ on:
       - main
       - dev
   pull_request:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ on:
       - dev
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- trigger the Tests workflow on merge_group so the required aggregate check is available in merge queue and ruleset enforcement
- trigger the Codecov workflow on merge_group for the same merge-group execution path

## Testing
- validated both workflow files parse as YAML locally

## Notes
- the repository ruleset on main now requires the `Required Status Check` GitHub Actions check