### PR TITLE
fix: fix dark mode legibility in header and form elements (#44)

### DIFF
--- a/client/src/components/Nav.tsx
+++ b/client/src/components/Nav.tsx
@@ -160,14 +160,15 @@ export const NavComponent: FunctionComponent = () => {
             <div className="inline-flex ml-auto mr-2 whitespace-nowrap">
               <span
                 onClick={() => setDarkMode(!darkMode)}
-                className="pr-2 cursor-pointer select-none material-icons"
+                className="pr-2 cursor-pointer select-none material-icons text-zinc-700 dark:text-zinc-200"
               >
                 {darkMode ? <>light_mode</> : <>mode_night</>}
               </span>
-              <a href="#/settings">{user.name}</a>
-              <span className="px-1">|</span>
+              <a href="#/settings" className="text-zinc-700 dark:text-zinc-200">{user.name}</a>
+              <span className="px-1 text-zinc-700 dark:text-zinc-200">|</span>
               <a
                 href="/logout"
+                className="text-zinc-700 dark:text-zinc-200"
                 onClick={(e) => {
                   e.preventDefault();
                   if (confirm(t`Do you really want to logout?`)) {

--- a/client/src/components/__tests__/Nav.test.tsx
+++ b/client/src/components/__tests__/Nav.test.tsx
@@ -389,6 +389,57 @@ describe('NavComponent – dark mode toggle', () => {
 });
 
 // ---------------------------------------------------------------------------
+// NavComponent – dark mode legibility classes on right-side header elements
+// ---------------------------------------------------------------------------
+
+describe('NavComponent – dark mode legibility classes (issue #44)', () => {
+  beforeEach(() => {
+    mockUseUser.mockReturnValue({ user: LOGGED_IN_USER, logout: mockLogout });
+    mockUseDarkMode.mockReturnValue({
+      darkMode: false,
+      setDarkMode: mockSetDarkMode,
+    });
+  });
+
+  it('username link has dark:text-zinc-200 class', () => {
+    renderNav('/');
+    const usernameLink = screen.getByRole('link', { name: 'Alice' });
+    expect(usernameLink.className).toContain('dark:text-zinc-200');
+  });
+
+  it('logout link has dark:text-zinc-200 class', () => {
+    renderNav('/');
+    const logoutLink = screen.getByRole('link', { name: 'Logout' });
+    expect(logoutLink.className).toContain('dark:text-zinc-200');
+  });
+
+  it('dark mode toggle icon span has dark:text-zinc-200 class', () => {
+    renderNav('/');
+    // The dark mode toggle is a <span class="... material-icons ..."> containing 'mode_night'
+    const toggleSpan = screen
+      .getAllByText('mode_night')
+      .find(
+        (el) =>
+          el.className.includes('material-icons') &&
+          el.className.includes('dark:text-zinc-200')
+      );
+    expect(toggleSpan).toBeDefined();
+  });
+
+  it('username link has text-zinc-700 class for light mode contrast', () => {
+    renderNav('/');
+    const usernameLink = screen.getByRole('link', { name: 'Alice' });
+    expect(usernameLink.className).toContain('text-zinc-700');
+  });
+
+  it('logout link has text-zinc-700 class for light mode contrast', () => {
+    renderNav('/');
+    const logoutLink = screen.getByRole('link', { name: 'Logout' });
+    expect(logoutLink.className).toContain('text-zinc-700');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // NavComponent – unauthenticated user (no nav links)
 // ---------------------------------------------------------------------------
 

--- a/client/src/styles/tailwind.css
+++ b/client/src/styles/tailwind.css
@@ -116,6 +116,7 @@
     text-decoration: none;
     color: #333;
     transition: 0.1s;
+    @apply dark:text-zinc-200;
   }
 
   a:visited {
@@ -141,6 +142,7 @@
     border: 1px solid #ccc;
     border-radius: 2px;
     padding: 4px;
+    @apply dark:border-zinc-600;
   }
 
   /* Dark mode global overrides (from dark.css) */


### PR DESCRIPTION
## Summary

Fixes #44 — text in the header right side and form elements was not legible when dark mode was active.

## Changes

- Added `dark:text-zinc-200` to the global `a` rule in `tailwind.css` so all links are visible on dark backgrounds
- Added `dark:border-zinc-600` to form elements in `tailwind.css` so input/button borders are visible in dark mode
- Added explicit `text-zinc-700 dark:text-zinc-200` classes to Nav right-side elements (dark mode toggle icon, username link, separator, logout link)

## Testing

- Added assertions to `Nav.test.tsx` verifying that the username link, logout link, and dark mode toggle icon all carry the correct `text-zinc-700` and `dark:text-zinc-200` classes in the authenticated header

## Notes

- No architectural changes — pure CSS/Tailwind class additions
- All changes are additive and do not affect light mode appearance