### PR TITLE
fix: replace hardcoded absolute path in coverage_report.js

### DIFF
--- a/client/coverage_report.js
+++ b/client/coverage_report.js
@@ -2,10 +2,7 @@ const j = require('./coverage/coverage-summary.json');
 const rows = Object.entries(j)
   .filter(([k]) => k !== 'total')
   .map(([k, v]) => ({
-    file: k.replace(
-      '/Users/lucas.rancez/Documents/Code/MediaTrackerPlus/trees/kevin/client/',
-      ''
-    ),
+    file: k.replace(/^.*\/client\//, ''),
     stmts: v.statements.pct,
     branches: v.branches.pct,
     funcs: v.functions.pct,


### PR DESCRIPTION
## Summary

`client/coverage_report.js` contained a hardcoded absolute path (`/Users/lucas.rancez/Documents/Code/MediaTrackerPlus/trees/kevin/client/`) that was machine-specific and leaked local filesystem information.

## Changes

- Replace the hardcoded absolute path string with a portable regex (`/^.*\/client\//`) that strips everything up to and including `/client/` from coverage report paths

## Testing

- Script produces correct relative paths regardless of where the repo is checked out
- No test suite changes needed (this is a standalone reporting utility)